### PR TITLE
allow for feature flagging rustls over native-tls in reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = """PagerDuty API from Rust."""
 
 
 [features]
-default = ["async"]
+default = ["async", "reqwest/default"]
 
 # Enable reqwest's blocking client on sync
 sync = ["reqwest/blocking"]
@@ -21,11 +21,13 @@ sync = ["reqwest/blocking"]
 # Need futures for Async
 async = []
 
+rustls = ["reqwest/rustls"]
+
 [dependencies]
 url = "2.2.2"
 time = {version = "0.3.5", features = ["std", "serde", "formatting", "macros"]}
 serde = {version = "1.0.132", features = ["derive"]}
-reqwest = { version = "0.11.8", features = ["json"]}
+reqwest = { version = "0.11.8", default-features = false, features = ["json"]}
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
This PR provides a way for users of pagerduty to disable reqwest's default features and use rustls over native-tls.